### PR TITLE
Add needed base_camera_optical_frame link/joint

### DIFF
--- a/fetch_description/robots/freight.urdf
+++ b/fetch_description/robots/freight.urdf
@@ -186,4 +186,10 @@
     <axis
       xyz="0 0 0" />
   </joint>
+  <link name="base_camera_optical_frame" />
+  <joint name="base_camera_optical_joint" type="fixed">
+    <origin rpy="-1.5707963267966 0 0" xyz="0 0 0" />
+    <parent link="base_camera_link" />
+    <child link="base_camera_optical_frame" />
+  </joint>
 </robot>


### PR DESCRIPTION
This is the needed frame.

We still need to double check that the resulting urdf is good, though.

The URDF I've been putting on robots has an empty base_camera_link and the origin for base_camera_joint is different...
